### PR TITLE
Fix: return msid

### DIFF
--- a/csv_generator/consumers/manuscript_consumer.py
+++ b/csv_generator/consumers/manuscript_consumer.py
@@ -25,7 +25,7 @@ class ManuscriptXMLConsumer(BaseXMLConsumer):
             msid = ''
         if not msid or not msid.isdigit():
             LOGGER.info('manuscript id "%s" invalid, ignoring %s', msid, xml_file_name)
-            return ''
+        return msid
 
     def process(self, soup: BeautifulSoup, xml_file_name: str) -> None:
         """


### PR DESCRIPTION
This fixed the failing tests.

Prior to this, if and `msid` was found it was never returned from `get_msid` only the blank `str` was returned.