### PR TITLE
Approved branch and image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,11 +25,18 @@ elifePipeline {
             stage 'Push image', {
                 image = DockerImage.elifesciences(this, "data-pipeline-airflow", commit)
                 image.push()
-                image.tag('latest').push()
             }
         }
     }
 
-
+    elifeMainlineOnly {
+        stage 'Approval', {
+            elifeGitMoveToBranch commit, 'approved'
+            node('containers-jenkins-plugin') {
+                image = DockerImage.elifesciences(this, "data-pipeline-airflow", commit)
+                image.pull().tag('approved').push()
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
The `approved` branch and image tag decouple successful testing from a production deployment. A separate `Jenkinsfile.prod` will be fed by the `approved` branch and push the `latest` image, to deploy it.